### PR TITLE
switch from text prop to children in Paragraph, Header and Code

### DIFF
--- a/specs/features/youtubeembed.feature
+++ b/specs/features/youtubeembed.feature
@@ -3,3 +3,7 @@ Feature: YouTubeEmbed component
   Scenario: Show default youtube embed
     When rendering youtube component with url "https://www.youtube.com/watch?v=w0JFqbDgKVQ"
     Then the youtube has src "https://www.youtube.com/embed/w0JFqbDgKVQ"
+
+  Scenario: Show default youtube embed with youtu.be link
+    When rendering youtube component with url "https://youtu.be/w0JFqbDgKVQ"
+    Then the youtube has src "https://www.youtube.com/embed/w0JFqbDgKVQ"

--- a/specs/step-definitions/code.steps.js
+++ b/specs/step-definitions/code.steps.js
@@ -11,7 +11,7 @@ defineFeature(feature, (test) => {
     test('Show default code', ({ when, then }) => {
         let code;
         when(/^rendering code component with text "(.*)"$/, (text) => {
-            code = renderer.create(<Code code={text} />);
+            code = renderer.create(<Code>{text}</Code>);
         });
 
         then(/^the code has text "(.*)"$/, (text) => {

--- a/specs/step-definitions/header.steps.js
+++ b/specs/step-definitions/header.steps.js
@@ -11,7 +11,7 @@ defineFeature(feature, (test) => {
     test('Show default header', ({ when, then, and }) => {
         let header;
         when(/^rendering header component with text "(.*)"$/, (text) => {
-            header = renderer.create(<Header text={text} />);
+            header = renderer.create(<Header>{text}</Header>);
         });
 
         then(/^the header has classes "(.*)"$/, (classes) => {

--- a/specs/step-definitions/paragraph.steps.js
+++ b/specs/step-definitions/paragraph.steps.js
@@ -11,7 +11,7 @@ defineFeature(feature, (test) => {
     test('Show default paragraph', ({ when, then }) => {
         let paragraph;
         when(/^rendering paragraph component with text "(.*)"$/, (text) => {
-            paragraph = renderer.create(<Paragraph text={text} />);
+            paragraph = renderer.create(<Paragraph>{text}</Paragraph>);
         });
 
         then(/^the paragraph has text "(.*)"$/, (text) => {

--- a/specs/step-definitions/youtubeembed.steps.js
+++ b/specs/step-definitions/youtubeembed.steps.js
@@ -19,4 +19,16 @@ defineFeature(feature, (test) => {
             expect(tree.children[0].props.src).toBe(src);
         });
     });
+
+    test('Show default youtube embed with youtu.be link', ({ when, then }) => {
+        let youtube;
+        when(/^rendering youtube component with url "(.*)"$/, (url) => {
+            youtube = renderer.create(<YouTubeEmbed url={url} />);
+        });
+
+        then(/^the youtube has src "(.*)"$/, (src) => {
+            const tree = youtube.toJSON();
+            expect(tree.children[0].props.src).toBe(src);
+        });
+    });
 });

--- a/src/components/Card/CardBody.js
+++ b/src/components/Card/CardBody.js
@@ -5,19 +5,21 @@ import { Context } from './Context';
 /**
  * Component for text body of card like component
  */
-const CardBody = ({ children, additionalClasses = [] }) => {
+const CardBody = ({ children, additionalClasses = [], ...props }) => {
     const context = useContext(Context);
 
     return (
-        <div className={[
-            'px-5',
-            'pt-5',
-            'pb-2',
-            'md:px-6',
-            'md:pt-6',
-            context.basisClassBody,
-            ...additionalClasses,
-        ].join(' ')}
+        <div
+            className={[
+                'px-5',
+                'pt-5',
+                'pb-2',
+                'md:px-6',
+                'md:pt-6',
+                context.basisClassBody,
+                ...additionalClasses,
+            ].join(' ')}
+            {...props}
         >
             {children}
         </div>

--- a/src/components/Card/CardImg.js
+++ b/src/components/Card/CardImg.js
@@ -5,16 +5,25 @@ import { Context } from './Context';
 /**
  * Component for image in card like component
  */
-const CardImg = ({ src, alt, additionalClasses = [], additionalContainerClasses = [] }) => {
+const CardImg = ({
+    src,
+    alt,
+    additionalClasses = [],
+    additionalContainerClasses = [],
+    imageAdditionalProps = {},
+    ...props
+}) => {
     const context = useContext(Context);
 
     return (
-        <div className={[
-            context.basisClassImage,
-            ...additionalContainerClasses,
-        ].join(' ')}
+        <div
+            className={[
+                context.basisClassImage,
+                ...additionalContainerClasses,
+            ].join(' ')}
+            {...props}
         >
-            <img src={src} alt={alt} className={additionalClasses.join(' ')} />
+            <img src={src} alt={alt} className={additionalClasses.join(' ')} {...imageAdditionalProps} />
         </div>
     );
 };
@@ -36,12 +45,17 @@ CardImg.propTypes = {
      * Additional classes for image container
      */
     additionalContainerClasses: PropTypes.arrayOf(PropTypes.string),
+    /**
+     * Additional props for image
+     */
+    imageAdditionalProps: PropTypes.shape({}),
 };
 
 CardImg.defaultProps = {
     additionalClasses: [],
     additionalContainerClasses: [],
     alt: false,
+    imageAdditionalProps: {},
 };
 
 export default CardImg;

--- a/src/components/Card/CardText.js
+++ b/src/components/Card/CardText.js
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types';
 /**
  * Standard text part of body in card like component
  */
-const CardText = ({ children, additionalClasses = [] }) => (
-    <p className={['text-base', 'font-light', 'my-4', ...additionalClasses].join(' ')}>
+const CardText = ({ children, additionalClasses = [], ...props }) => (
+    <p className={['text-base', 'font-light', 'my-4', ...additionalClasses].join(' ')} {...props}>
         {children}
     </p>
 );

--- a/src/components/Card/CardTitle.js
+++ b/src/components/Card/CardTitle.js
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types';
 /**
  * Header text of body in card like component
  */
-const CardTitle = ({ children, additionalClasses = [] }) => (
-    <h2 className={['text-3xl', 'font-semibold', 'leading-10', ...additionalClasses].join(' ')}>
+const CardTitle = ({ children, additionalClasses = [], ...props }) => (
+    <h2 className={['text-3xl', 'font-semibold', 'leading-10', ...additionalClasses].join(' ')} {...props}>
         {children}
     </h2>
 );

--- a/src/components/Code/Code.js
+++ b/src/components/Code/Code.js
@@ -5,18 +5,18 @@ import PropTypes from 'prop-types';
  * Component for highlighting code.
  * Install highlight.js to make the component looks like in the examples, we use nord.css
  */
-const Code = ({ code, language, highlight, additionalClasses, ...props }) => {
+const Code = ({ children, language, highlight, additionalClasses, ...props }) => {
     useEffect(() => {
         if (highlight) {
             highlight.highlightAll();
         }
-    }, [highlight, language, code]);
-    let CodeToDisplay = code;
+    }, [highlight, language, children]);
+    let CodeToDisplay = children;
     let lang = language;
-    if (code.indexOf('```') === 0) {
+    if (children.indexOf('```') === 0) {
         // eslint-disable-next-line prefer-destructuring
-        lang = code.split('```')[1];
-        const blocks = code.split('\n');
+        lang = children.split('```')[1];
+        const blocks = children.split('\n');
         blocks.splice(0, 1);
         CodeToDisplay = blocks.join('\n');
     }
@@ -38,7 +38,7 @@ Code.propTypes = {
     /**
      * Code content
      */
-    code: PropTypes.string.isRequired,
+    children: PropTypes.string.isRequired,
     /**
      * Programming language name
      */

--- a/src/components/Content/Content.js
+++ b/src/components/Content/Content.js
@@ -43,21 +43,23 @@ const Content = ({
             return (
                 <Header
                     level={block.data.level}
-                    text={block.data.text}
                     anchor={block.data.anchor}
                     alignment={block.tunes?.alignmentTuneTool?.alignment}
                     {...headerProps}
                     key={block.id}
-                />
+                >
+                    {block.data.text}
+                </Header>
             );
         case 'paragraph':
             return (
                 <Paragraph
-                    text={block.data.text}
                     alignment={block.tunes?.alignmentTuneTool?.alignment}
                     {...paragraphProps}
                     key={block.id}
-                />
+                >
+                    {block.data.text}
+                </Paragraph>
             );
         case 'list':
             return (
@@ -109,10 +111,11 @@ const Content = ({
         case 'code':
             return (
                 <Code
-                    code={block.data.code}
                     {...codeProps}
                     key={block.id}
-                />
+                >
+                    {block.data.code}
+                </Code>
             );
         case 'warning':
             return (

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
  */
 const Header = ({
     level,
-    text,
+    children,
     anchor,
     alignment,
     additionalClasses,
@@ -35,18 +35,18 @@ const Header = ({
     };
 
     return (
-        React.isValidElement(text) ? (
+        React.isValidElement(children) ? (
             <HeaderToRender
                 className={[sizeClass[safeLevel], alignmentClass[alignment], ...additionalClasses].join(' ')}
                 id={anchor}
                 {...props}
             >
-                {text}
+                {children}
             </HeaderToRender>
         ) : (
             <HeaderToRender
                 className={[sizeClass[safeLevel], alignmentClass[alignment], ...additionalClasses].join(' ')}
-                dangerouslySetInnerHTML={{ __html: text }}
+                dangerouslySetInnerHTML={{ __html: children }}
                 id={anchor}
                 {...props}
             />
@@ -62,7 +62,7 @@ Header.propTypes = {
     /**
      * Header contents
      */
-    text: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+    children: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
     /**
      * Header anchor
      */

--- a/src/components/Paragraph/Paragraph.js
+++ b/src/components/Paragraph/Paragraph.js
@@ -4,23 +4,23 @@ import PropTypes from 'prop-types';
 /**
  * Component for standard text
  */
-const Paragraph = ({ text, alignment, additionalClasses, ...props }) => {
+const Paragraph = ({ alignment, additionalClasses, children, ...props }) => {
     const alignmentClass = {
         left: 'text-left',
         center: 'text-center',
         right: 'text-right',
     };
-    return React.isValidElement(text) ? (
-        <p
+    return React.isValidElement(children) ? (
+        <div
             className={['py-2', alignmentClass[alignment], ...additionalClasses].join(' ')}
             {...props}
         >
-            {text}
-        </p>
+            {children}
+        </div>
     ) : (
-        <p
+        <div
             className={['py-2', alignmentClass[alignment], ...additionalClasses].join(' ')}
-            dangerouslySetInnerHTML={{ __html: text }}
+            dangerouslySetInnerHTML={{ __html: children }}
             {...props}
         />
     );
@@ -30,7 +30,7 @@ Paragraph.propTypes = {
     /**
      * Paragraph content
      */
-    text: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+    children: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
     /**
      * Paragraph alignment
      */

--- a/src/components/PoweredByFlotiq/PoweredByFlotiq.js
+++ b/src/components/PoweredByFlotiq/PoweredByFlotiq.js
@@ -12,7 +12,13 @@ const PoweredByFlotiq = ({ badge, text, additionalClasses, ...props }) => (badge
             'fixed', 'bottom-[20px]', 'right-[20px]', 'text-xs',
             'bg-white', 'border', 'border-light-blue', ...additionalClasses].join(' ')}
     >
-        <img src={LogoBadge} width="11" height="11" alt="Flotiq" className="mr-1" />
+        <img
+            src={LogoBadge}
+            width={11}
+            height={11}
+            alt="Flotiq"
+            className="mr-1"
+        />
         <a href="https://flotiq.com" target="_blank" rel="noreferrer">{text}</a>
     </div>
 ) : (
@@ -21,6 +27,8 @@ const PoweredByFlotiq = ({ badge, text, additionalClasses, ...props }) => (badge
             className="block h-5 md:h-6 w-auto mr-2"
             src={LogoBadge}
             alt="Flotiq"
+            width={274.96}
+            height={276}
         />
         <p className="text-center text-xs md:text-base font-semibold">
             <a href="https://flotiq.com" target="_blank" rel="noreferrer">{text}</a>

--- a/src/components/Quote/Quote.js
+++ b/src/components/Quote/Quote.js
@@ -10,15 +10,15 @@ const Quote = ({
 }) => (
     <div className={['flex flex-col italic', ...additionalClasses].join(' ')} {...props}>
         {React.isValidElement(text) ? (
-            <p
+            <div
                 className={[
                     'pl-6 md:pl-10 py-4 border-l-4', borderProps.classSet[variant], ...quoteAdditionalClasses,
                 ].join(' ')}
             >
                 {text}
-            </p>
+            </div>
         ) : (
-            <p
+            <div
                 className={[
                     'pl-6 md:pl-10 py-4 border-l-4', borderProps.classSet[variant], ...quoteAdditionalClasses,
                 ].join(' ')}

--- a/src/components/YouTubeEmbed/YouTubeEmbed.js
+++ b/src/components/YouTubeEmbed/YouTubeEmbed.js
@@ -11,7 +11,8 @@ const YouTubeEmbed = ({
     additionalClasses,
     ...props
 }) => {
-    const safeUrl = url.replace('/watch?v=', '/embed/');
+    let safeUrl = url.replace('/watch?v=', '/embed/');
+    safeUrl = safeUrl.replace('youtu.be/', 'www.youtube.com/embed/');
     return (
         <div className="height-0 pb-[56.25%] relative">
             <iframe

--- a/src/stories/Code.stories.js
+++ b/src/stories/Code.stories.js
@@ -25,7 +25,7 @@ const Template = (args) => <Code {...args} highlight={highlight} />;
 export const Base = Template.bind({});
 // More on args: https://storybook.js.org/docs/react/writing-stories/args
 Base.args = {
-    code: 'const example = "Flotiq is great!"',
+    children: 'const example = "Flotiq is great!"',
     ...Code.defaultProps,
     language: 'javascript',
 };

--- a/src/stories/Header.stories.js
+++ b/src/stories/Header.stories.js
@@ -19,7 +19,7 @@ export const Level1 = Template.bind({});
 // More on args: https://storybook.js.org/docs/react/writing-stories/args
 Level1.args = {
     ...Header.defaultProps,
-    text: 'Heading 1',
+    children: 'Heading 1',
 };
 
 export const Level2 = Template.bind({});
@@ -27,7 +27,7 @@ export const Level2 = Template.bind({});
 Level2.args = {
     ...Header.defaultProps,
     level: 2,
-    text: 'What is a <b>CMS</b>',
+    children: 'What is a <b>CMS</b>',
     alignment: 'center',
 };
 
@@ -36,7 +36,7 @@ export const Level3 = Template.bind({});
 Level3.args = {
     ...Header.defaultProps,
     level: 3,
-    text: 'Heading 3',
+    children: 'Heading 3',
     alignment: 'right',
 };
 
@@ -45,7 +45,7 @@ export const Level4 = Template.bind({});
 Level4.args = {
     ...Header.defaultProps,
     level: 4,
-    text: 'Heading 4',
+    children: 'Heading 4',
 };
 
 export const Level5 = Template.bind({});
@@ -53,7 +53,7 @@ export const Level5 = Template.bind({});
 Level5.args = {
     ...Header.defaultProps,
     level: 5,
-    text: 'Heading 5',
+    children: 'Heading 5',
 };
 
 export const Level6 = Template.bind({});
@@ -61,5 +61,5 @@ export const Level6 = Template.bind({});
 Level6.args = {
     ...Header.defaultProps,
     level: 6,
-    text: 'Heading 6',
+    children: 'Heading 6',
 };

--- a/src/stories/Paragraph.stories.js
+++ b/src/stories/Paragraph.stories.js
@@ -18,7 +18,7 @@ const Template = (args) => <Paragraph {...args} />;
 export const Base = Template.bind({});
 // More on args: https://storybook.js.org/docs/react/writing-stories/args
 Base.args = {
-    text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec condimentum augue vitae rhoncus vehicula.'
+    children: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec condimentum augue vitae rhoncus vehicula.'
         + ' Phasellus aliquam leo eu porta scelerisque. In et vestibulum ex. Aliquam erat volutpat.'
         + ' Nullam vehicula tortor vitae lorem egestas imperdiet.'
         + ' Vestibulum molestie sem mollis, commodo neque vitae, posuere urna.'


### PR DESCRIPTION
switch from text prop to children in Paragraph, Header and Code components, add missing width and height in Power by Flotiq component, add missing ...props in Card subcomponents, add possibility od youtu.be links in YouTube Embed component, switch from p to div in Quote component to avoid gatsby build problems with dangerouslySetInnerHTML