### PR TITLE
Feature/maciejl/23126 caption with html img fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flotiq-components-react",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "dist/index.js",
   "private": false,
   "author": "Flotiq team <hello@flotiq.com>",

--- a/src/components/Image/Image.js
+++ b/src/components/Image/Image.js
@@ -15,7 +15,7 @@ const Image = ({ url, caption, stretched, rounded, additionalClasses, captionAdd
             ].join(' ')}
             {...props}
         />
-        {caption && <p className={['pt-2 opacity-70 italic', ...captionAdditionalClasses].join(' ')}>{caption}</p>}
+        {caption && <p className={['pt-2 opacity-70 italic', ...captionAdditionalClasses].join(' ')} dangerouslySetInnerHTML={{ __html: caption }}/>}
     </>
 );
 

--- a/src/stories/defaultContent/defaultContent.js
+++ b/src/stories/defaultContent/defaultContent.js
@@ -89,7 +89,7 @@ export const blocks = [
             url: 'https://api.flotiq.com/image/0x0/_media-3a62e398-fbe3-46e8-ba5b-05a2690390ae.png',
             width: 1328,
             height: 758,
-            caption: 'Example Caption',
+            caption: 'Example <b>Caption</b> <i>with</i> link to <a href="http://flotiq.com">flotiq.com</a>',
             fileName: 'example.png',
             extension: 'png',
             stretched: true,


### PR DESCRIPTION
Add example with html for caption.
Fix html parse for image caption.

Before:
![before-fix](https://github.com/flotiq/flotiq-components-react/assets/110835434/1bf000b8-5f5f-4e2b-99e4-e7006b4f579f)

After:
![after-fix](https://github.com/flotiq/flotiq-components-react/assets/110835434/34f38553-b8b5-43cb-8e50-c5172093b191)
