### PR TITLE
fix incorrect prop types recognition

### DIFF
--- a/dist/components/Audio/Audio.js
+++ b/dist/components/Audio/Audio.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.defaults = exports.default = void 0;
+exports.defaults = exports.default = exports.audioPropTypes = void 0;
 var _react = _interopRequireDefault(require("react"));
 var _propTypes = _interopRequireDefault(require("prop-types"));
 function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
@@ -36,6 +36,20 @@ const Audio = _ref => {
     className: "pt-2 md:pt-5 opacity-70 italic"
   }, caption));
 };
+const audioPropTypes = exports.audioPropTypes = {
+  /**
+   * File extension
+   */
+  extension: _propTypes.default.string,
+  /**
+   * File caption
+   */
+  caption: _propTypes.default.string,
+  /**
+   * Additional classes for audio
+   */
+  additionalClasses: _propTypes.default.arrayOf(_propTypes.default.string)
+};
 Audio.propTypes = {
   /**
    * File url
@@ -45,13 +59,6 @@ Audio.propTypes = {
    * File extension
    */
   extension: _propTypes.default.string.isRequired,
-  /**
-   * File caption
-   */
-  caption: _propTypes.default.string,
-  /**
-   * Additional classes for audio
-   */
-  additionalClasses: _propTypes.default.arrayOf(_propTypes.default.string)
+  ...audioPropTypes
 };
 var _default = exports.default = Audio;

--- a/dist/components/Code/Code.js
+++ b/dist/components/Code/Code.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.defaults = exports.default = void 0;
+exports.defaults = exports.default = exports.codePropTypes = void 0;
 var _react = _interopRequireWildcard(require("react"));
 var _propTypes = _interopRequireDefault(require("prop-types"));
 function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
@@ -47,11 +47,7 @@ const Code = _ref => {
     className: `language-${lang}`
   }, CodeToDisplay)));
 };
-Code.propTypes = {
-  /**
-   * Code content
-   */
-  children: _propTypes.default.string.isRequired,
+const codePropTypes = exports.codePropTypes = {
   /**
    * Programming language name
    */
@@ -60,5 +56,12 @@ Code.propTypes = {
    * Additional classes for code
    */
   additionalClasses: _propTypes.default.arrayOf(_propTypes.default.string)
+};
+Code.propTypes = {
+  ...codePropTypes,
+  /**
+   * Code content
+   */
+  children: _propTypes.default.string.isRequired
 };
 var _default = exports.default = Code;

--- a/dist/components/Content/Content.js
+++ b/dist/components/Content/Content.js
@@ -6,16 +6,16 @@ Object.defineProperty(exports, "__esModule", {
 exports.defaults = exports.default = void 0;
 var _react = _interopRequireWildcard(require("react"));
 var _propTypes = _interopRequireDefault(require("prop-types"));
-var _Code = _interopRequireDefault(require("../Code/Code"));
-var _Delimiter = _interopRequireDefault(require("../Delimiter/Delimiter"));
-var _File = _interopRequireDefault(require("../File/File"));
-var _Header = _interopRequireDefault(require("../Header/Header"));
-var _List = _interopRequireDefault(require("../List/List"));
-var _Paragraph = _interopRequireDefault(require("../Paragraph/Paragraph"));
-var _Quote = _interopRequireDefault(require("../Quote/Quote"));
-var _Table = _interopRequireDefault(require("../Table/Table"));
-var _Warning = _interopRequireDefault(require("../Warning/Warning"));
-var _YouTubeEmbed = _interopRequireDefault(require("../YouTubeEmbed/YouTubeEmbed"));
+var _Code = _interopRequireWildcard(require("../Code/Code"));
+var _Delimiter = _interopRequireWildcard(require("../Delimiter/Delimiter"));
+var _File = _interopRequireWildcard(require("../File/File"));
+var _Header = _interopRequireWildcard(require("../Header/Header"));
+var _List = _interopRequireWildcard(require("../List/List"));
+var _Paragraph = _interopRequireWildcard(require("../Paragraph/Paragraph"));
+var _Quote = _interopRequireWildcard(require("../Quote/Quote"));
+var _Table = _interopRequireWildcard(require("../Table/Table"));
+var _Warning = _interopRequireWildcard(require("../Warning/Warning"));
+var _YouTubeEmbed = _interopRequireWildcard(require("../YouTubeEmbed/YouTubeEmbed"));
 function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
 function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function (e) { return e ? t : r; })(e); }
 function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != typeof e && "function" != typeof e) return { default: e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && {}.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n.default = e, t && t.set(e, n), n; }
@@ -90,7 +90,7 @@ const Content = _ref => {
           caption: block.data.caption,
           fileName: block.data.fileName,
           extension: block.data.extension,
-          stretched: block.data.stretched
+          stretched: !!block.data.stretched
         }, fileProps, {
           key: block.id
         }));
@@ -145,43 +145,43 @@ Content.propTypes = {
   /**
    * Additional props for header component, for more information check Header component
    */
-  headerProps: _Header.default.propTypes,
+  headerProps: _propTypes.default.shape(_Header.headerPropTypes),
   /**
    * Additional props for paragraph component, for more information check Paragraph component
    */
-  paragraphProps: _Paragraph.default.propTypes,
+  paragraphProps: _propTypes.default.shape(_Paragraph.paragraphPropTypes),
   /**
    * Additional props for YouTube embed component, for more information check YouTubeEmbed component
    */
-  youTubeEmbedProps: _YouTubeEmbed.default.propTypes,
+  youTubeEmbedProps: _propTypes.default.shape(_YouTubeEmbed.youTubeEmbedPropTypes),
   /**
    * Additional props for file components, for more information check File component
    */
-  fileProps: _File.default.propTypes,
+  fileProps: _propTypes.default.shape(_File.filePropTypes),
   /**
    * Additional props for quote component, for more information check Quote components
    */
-  quoteProps: _Quote.default.propTypes,
+  quoteProps: _propTypes.default.shape(_Quote.quotePropTypes),
   /**
    * Additional props for table component, for more information check Table component
    */
-  tableProps: _Table.default.propTypes,
+  tableProps: _propTypes.default.shape(_Table.tablePropTypes),
   /**
    * Additional props for code component, for more information check Code component
    */
-  codeProps: _Code.default.propTypes,
+  codeProps: _propTypes.default.shape(_Code.codePropTypes),
   /**
    * Additional props for warning component, for more information check Warning component
    */
-  warningProps: _Warning.default.propTypes,
+  warningProps: _propTypes.default.shape(_Warning.warningPropTypes),
   /**
    * Additional props for delimiter component, for more information check Delimiter component
    */
-  delimiterProps: _Delimiter.default.propTypes,
+  delimiterProps: _propTypes.default.shape(_Delimiter.delimiterPropTypes),
   /**
    * Additional components for list component, for more information check List component
    */
-  listProps: _List.default.propTypes,
+  listProps: _propTypes.default.shape(_List.listPropTypes),
   /**
    * Standard horizontal padding for block components
    */

--- a/dist/components/Delimiter/Delimiter.js
+++ b/dist/components/Delimiter/Delimiter.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.defaults = exports.default = void 0;
+exports.delimiterPropTypes = exports.defaults = exports.default = void 0;
 var _react = _interopRequireDefault(require("react"));
 var _propTypes = _interopRequireDefault(require("prop-types"));
 var _border = require("../../defaultProps/border");
@@ -34,7 +34,7 @@ const Delimiter = _ref => {
     className: ['my-2', _border.borderProps.classSet[variant], styleClasses[style], ...additionalClasses].join(' ')
   }, props));
 };
-Delimiter.propTypes = {
+const delimiterPropTypes = exports.delimiterPropTypes = {
   /**
    * Delimiter variant
    */
@@ -48,4 +48,5 @@ Delimiter.propTypes = {
    */
   additionalClasses: _propTypes.default.arrayOf(_propTypes.default.string)
 };
+Delimiter.propTypes = delimiterPropTypes;
 var _default = exports.default = Delimiter;

--- a/dist/components/File/File.js
+++ b/dist/components/File/File.js
@@ -3,12 +3,14 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.defaults = exports.default = void 0;
+exports.filePropTypes = exports.defaults = exports.default = void 0;
 var _react = _interopRequireDefault(require("react"));
 var _propTypes = _interopRequireDefault(require("prop-types"));
-var _Image = _interopRequireDefault(require("../Image/Image"));
-var _Video = _interopRequireDefault(require("../Video/Video"));
-var _Audio = _interopRequireDefault(require("../Audio/Audio"));
+var _Image = _interopRequireWildcard(require("../Image/Image"));
+var _Video = _interopRequireWildcard(require("../Video/Video"));
+var _Audio = _interopRequireWildcard(require("../Audio/Audio"));
+function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function (e) { return e ? t : r; })(e); }
+function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != typeof e && "function" != typeof e) return { default: e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && {}.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n.default = e, t && t.set(e, n), n; }
 function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
 function _extends() { return _extends = Object.assign ? Object.assign.bind() : function (n) { for (var e = 1; e < arguments.length; e++) { var t = arguments[e]; for (var r in t) ({}).hasOwnProperty.call(t, r) && (n[r] = t[r]); } return n; }, _extends.apply(null, arguments); }
 const defaults = exports.defaults = {
@@ -62,11 +64,7 @@ const File = _ref => {
 const isMovie = extension => ['mp4', 'webm', 'ogv'].indexOf(extension) > -1;
 const isImage = extension => ['jpg', 'png', 'bmp', 'svg', 'gif', 'webp', 'ico'].indexOf(extension) > -1;
 const isAudio = extension => ['mpeg', 'mp3', 'mid', 'ogg', 'oga', 'wav'].indexOf(extension) > -1;
-File.propTypes = {
-  /**
-   * File url
-   */
-  url: _propTypes.default.string.isRequired,
+const filePropTypes = exports.filePropTypes = {
   /**
    * File caption
    */
@@ -78,7 +76,7 @@ File.propTypes = {
   /**
    * File extension
    */
-  extension: _propTypes.default.string.isRequired,
+  extension: _propTypes.default.string,
   /**
    * File name
    */
@@ -86,18 +84,29 @@ File.propTypes = {
   /**
    * Additional props for image components, for more information check Image component
    */
-  imageProps: _Image.default.propTypes,
+  imageProps: _propTypes.default.shape(_Image.imagePropTypes),
   /**
    * Additional props for video components, for more information check Video component
    */
-  videoProps: _Video.default.propTypes,
+  videoProps: _propTypes.default.shape(_Video.videoPropTypes),
   /**
    * Additional props for audio components, for more information check Audio component
    */
-  audioProps: _Audio.default.propTypes,
+  audioProps: _propTypes.default.shape(_Audio.audioPropTypes),
   /**
    * Additional classes for file
    */
   additionalClasses: _propTypes.default.arrayOf(_propTypes.default.string)
+};
+File.propTypes = {
+  /**
+   * File url
+   */
+  url: _propTypes.default.string.isRequired,
+  /**
+   * File extension
+   */
+  extension: _propTypes.default.string.isRequired,
+  ...filePropTypes
 };
 var _default = exports.default = File;

--- a/dist/components/Header/Header.js
+++ b/dist/components/Header/Header.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.defaults = exports.default = void 0;
+exports.headerPropTypes = exports.defaults = exports.default = void 0;
 var _react = _interopRequireDefault(require("react"));
 var _propTypes = _interopRequireDefault(require("prop-types"));
 function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
@@ -65,15 +65,11 @@ const Header = _ref => {
     id: anchor
   }, props));
 };
-Header.propTypes = {
+const headerPropTypes = exports.headerPropTypes = {
   /**
    * Level of header
    */
   level: _propTypes.default.number,
-  /**
-   * Header contents
-   */
-  children: _propTypes.default.oneOfType([_propTypes.default.string, _propTypes.default.element]).isRequired,
   /**
    * Header anchor
    */
@@ -110,5 +106,12 @@ Header.propTypes = {
    * Additional classes for level 6 header
    */
   h6AdditionalClasses: _propTypes.default.arrayOf(_propTypes.default.string)
+};
+Header.propTypes = {
+  /**
+   * Header contents
+   */
+  children: _propTypes.default.oneOfType([_propTypes.default.string, _propTypes.default.element]).isRequired,
+  ...headerPropTypes
 };
 var _default = exports.default = Header;

--- a/dist/components/Image/Image.js
+++ b/dist/components/Image/Image.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.defaults = exports.default = void 0;
+exports.imagePropTypes = exports.defaults = exports.default = void 0;
 var _react = _interopRequireDefault(require("react"));
 var _propTypes = _interopRequireDefault(require("prop-types"));
 var _rounded = require("../../defaultProps/rounded");
@@ -41,11 +41,11 @@ const Image = _ref => {
     }
   }));
 };
-Image.propTypes = {
+const imagePropTypes = exports.imagePropTypes = {
   /**
    * Image url
    */
-  url: _propTypes.default.string.isRequired,
+  url: _propTypes.default.string,
   /**
    * Image caption
    */
@@ -66,5 +66,12 @@ Image.propTypes = {
    * Additional classes for image caption
    */
   captionAdditionalClasses: _propTypes.default.arrayOf(_propTypes.default.string)
+};
+Image.propTypes = {
+  ...imagePropTypes,
+  /**
+   * Image url
+   */
+  url: _propTypes.default.string.isRequired
 };
 var _default = exports.default = Image;

--- a/dist/components/List/List.js
+++ b/dist/components/List/List.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.defaults = exports.default = void 0;
+exports.listPropTypes = exports.defaults = exports.default = void 0;
 var _react = _interopRequireWildcard(require("react"));
 var _propTypes = _interopRequireDefault(require("prop-types"));
 function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
@@ -52,11 +52,11 @@ const Items = {
   content: _propTypes.default.oneOfType([_propTypes.default.string, _propTypes.default.element]).isRequired
 };
 Items.items = _propTypes.default.arrayOf(_propTypes.default.shape(Items));
-List.propTypes = {
+const listPropTypes = exports.listPropTypes = {
   /**
    * List content
    */
-  items: _propTypes.default.arrayOf(_propTypes.default.shape(Items)).isRequired,
+  items: _propTypes.default.arrayOf(_propTypes.default.shape(Items)),
   /**
    * List style
    */
@@ -69,5 +69,12 @@ List.propTypes = {
    * Additional classes for list
    */
   additionalClasses: _propTypes.default.arrayOf(_propTypes.default.string)
+};
+List.propTypes = {
+  ...listPropTypes,
+  /**
+   * List content
+   */
+  items: _propTypes.default.arrayOf(_propTypes.default.shape(Items)).isRequired
 };
 var _default = exports.default = List;

--- a/dist/components/Paragraph/Paragraph.js
+++ b/dist/components/Paragraph/Paragraph.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.defaults = exports.default = void 0;
+exports.paragraphPropTypes = exports.defaults = exports.default = void 0;
 var _react = _interopRequireDefault(require("react"));
 var _propTypes = _interopRequireDefault(require("prop-types"));
 function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
@@ -38,11 +38,7 @@ const Paragraph = _ref => {
     }
   }, props));
 };
-Paragraph.propTypes = {
-  /**
-   * Paragraph content
-   */
-  children: _propTypes.default.oneOfType([_propTypes.default.string, _propTypes.default.element]).isRequired,
+const paragraphPropTypes = exports.paragraphPropTypes = {
   /**
    * Paragraph alignment
    */
@@ -51,5 +47,12 @@ Paragraph.propTypes = {
    * Additional classes for paragraph
    */
   additionalClasses: _propTypes.default.arrayOf(_propTypes.default.string)
+};
+Paragraph.propTypes = {
+  /**
+   * Paragraph content
+   */
+  children: _propTypes.default.oneOfType([_propTypes.default.string, _propTypes.default.element]).isRequired,
+  ...paragraphPropTypes
 };
 var _default = exports.default = Paragraph;

--- a/dist/components/Quote/Quote.js
+++ b/dist/components/Quote/Quote.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.defaults = exports.default = void 0;
+exports.quotePropTypes = exports.defaults = exports.default = void 0;
 var _react = _interopRequireDefault(require("react"));
 var _propTypes = _interopRequireDefault(require("prop-types"));
 var _border = require("../../defaultProps/border");
@@ -42,15 +42,15 @@ const Quote = _ref => {
     className: ['self-end mt-3 py-1.5 opacity-70', ...captionAdditionalClasses].join(' ')
   }, caption));
 };
-Quote.propTypes = {
+const quotePropTypes = exports.quotePropTypes = {
   /**
    * Quote content
    */
-  text: _propTypes.default.oneOfType([_propTypes.default.string, _propTypes.default.element]).isRequired,
+  text: _propTypes.default.oneOfType([_propTypes.default.string, _propTypes.default.element]),
   /**
    * Quote caption
    */
-  caption: _propTypes.default.string.isRequired,
+  caption: _propTypes.default.string,
   /**
    * Quote variant
    */
@@ -67,5 +67,16 @@ Quote.propTypes = {
    * Additional classes for quote caption
    */
   captionAdditionalClasses: _propTypes.default.arrayOf(_propTypes.default.string)
+};
+Quote.propTypes = {
+  ...quotePropTypes,
+  /**
+   * Quote content
+   */
+  text: _propTypes.default.oneOfType([_propTypes.default.string, _propTypes.default.element]).isRequired,
+  /**
+   * Quote caption
+   */
+  caption: _propTypes.default.string.isRequired
 };
 var _default = exports.default = Quote;

--- a/dist/components/Table/Table.js
+++ b/dist/components/Table/Table.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.defaults = exports.default = void 0;
+exports.tablePropTypes = exports.defaults = exports.default = void 0;
 var _react = _interopRequireDefault(require("react"));
 var _propTypes = _interopRequireDefault(require("prop-types"));
 function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
@@ -38,7 +38,7 @@ const Table = _ref => {
     key: column
   }, column))))));
 };
-Table.propTypes = {
+const tablePropTypes = exports.tablePropTypes = {
   /**
    * Table contents
    */
@@ -52,4 +52,5 @@ Table.propTypes = {
    */
   additionalClasses: _propTypes.default.arrayOf(_propTypes.default.string)
 };
+Table.propTypes = tablePropTypes;
 var _default = exports.default = Table;

--- a/dist/components/Video/Video.js
+++ b/dist/components/Video/Video.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.defaults = exports.default = void 0;
+exports.videoPropTypes = exports.defaults = exports.default = void 0;
 var _react = _interopRequireDefault(require("react"));
 var _propTypes = _interopRequireDefault(require("prop-types"));
 function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
@@ -36,15 +36,15 @@ const Video = _ref => {
     className: "pt-2 opacity-70 italic"
   }, caption));
 };
-Video.propTypes = {
+const videoPropTypes = exports.videoPropTypes = {
   /**
    * Video url
    */
-  url: _propTypes.default.string.isRequired,
+  url: _propTypes.default.string,
   /**
    * File extension
    */
-  extension: _propTypes.default.string.isRequired,
+  extension: _propTypes.default.string,
   /**
    * Video caption
    */
@@ -53,5 +53,16 @@ Video.propTypes = {
    * Additional classes for video
    */
   additionalClasses: _propTypes.default.arrayOf(_propTypes.default.string)
+};
+Video.propTypes = {
+  ...videoPropTypes,
+  /**
+   * Video url
+   */
+  url: _propTypes.default.string.isRequired,
+  /**
+   * File extension
+   */
+  extension: _propTypes.default.string.isRequired
 };
 var _default = exports.default = Video;

--- a/dist/components/Warning/Warning.js
+++ b/dist/components/Warning/Warning.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.defaults = exports.default = void 0;
+exports.warningPropTypes = exports.defaults = exports.default = void 0;
 var _react = _interopRequireDefault(require("react"));
 var _propTypes = _interopRequireDefault(require("prop-types"));
 function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
@@ -32,7 +32,22 @@ const Warning = _ref => {
     className: "text-warning-800"
   }, message));
 };
+const warningPropTypes = exports.warningPropTypes = {
+  /**
+   * Warning message
+   */
+  message: _propTypes.default.string,
+  /**
+   * Warning title
+   */
+  title: _propTypes.default.string,
+  /**
+   * Additional classes for warning
+   */
+  additionalClasses: _propTypes.default.arrayOf(_propTypes.default.string)
+};
 Warning.propTypes = {
+  ...warningPropTypes,
   /**
    * Warning message
    */
@@ -40,10 +55,6 @@ Warning.propTypes = {
   /**
    * Warning title
    */
-  title: _propTypes.default.string.isRequired,
-  /**
-   * Additional classes for warning
-   */
-  additionalClasses: _propTypes.default.arrayOf(_propTypes.default.string)
+  title: _propTypes.default.string.isRequired
 };
 var _default = exports.default = Warning;

--- a/dist/components/YouTubeEmbed/YouTubeEmbed.js
+++ b/dist/components/YouTubeEmbed/YouTubeEmbed.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.defaults = exports.default = void 0;
+exports.youTubeEmbedPropTypes = exports.defaults = exports.default = void 0;
 var _react = _interopRequireDefault(require("react"));
 var _propTypes = _interopRequireDefault(require("prop-types"));
 function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
@@ -41,11 +41,11 @@ const YouTubeEmbed = _ref => {
     className: ['absolute', 'w-full', 'h-full', ...additionalClasses].join(' ')
   }, props)));
 };
-YouTubeEmbed.propTypes = {
+const youTubeEmbedPropTypes = exports.youTubeEmbedPropTypes = {
   /**
-   * YouTUbe url
+   * YouTube url
    */
-  url: _propTypes.default.string.isRequired,
+  url: _propTypes.default.string,
   /**
    * Title of iframe
    */
@@ -58,5 +58,12 @@ YouTubeEmbed.propTypes = {
    * Additional classes for embed
    */
   additionalClasses: _propTypes.default.arrayOf(_propTypes.default.string)
+};
+YouTubeEmbed.propTypes = {
+  ...youTubeEmbedPropTypes,
+  /**
+   * YouTube url
+   */
+  url: _propTypes.default.string.isRequired
 };
 var _default = exports.default = YouTubeEmbed;

--- a/dist/index-including-tailwind.css
+++ b/dist/index-including-tailwind.css
@@ -611,6 +611,9 @@ video {
 .mt-3 {
   margin-top: 0.75rem;
 }
+.\!block {
+  display: block !important;
+}
 .block {
   display: block;
 }

--- a/src/components/Audio/Audio.js
+++ b/src/components/Audio/Audio.js
@@ -26,6 +26,21 @@ const Audio = ({
     </div>
 );
 
+export const audioPropTypes = {
+    /**
+     * File extension
+     */
+    extension: PropTypes.string,
+    /**
+     * File caption
+     */
+    caption: PropTypes.string,
+    /**
+     * Additional classes for audio
+     */
+    additionalClasses: PropTypes.arrayOf(PropTypes.string),
+};
+
 Audio.propTypes = {
     /**
      * File url
@@ -35,14 +50,7 @@ Audio.propTypes = {
      * File extension
      */
     extension: PropTypes.string.isRequired,
-    /**
-     * File caption
-     */
-    caption: PropTypes.string,
-    /**
-     * Additional classes for audio
-     */
-    additionalClasses: PropTypes.arrayOf(PropTypes.string),
+    ...audioPropTypes,
 };
 
 export default Audio;

--- a/src/components/Code/Code.js
+++ b/src/components/Code/Code.js
@@ -45,11 +45,7 @@ const Code = ({
     );
 };
 
-Code.propTypes = {
-    /**
-     * Code content
-     */
-    children: PropTypes.string.isRequired,
+export const codePropTypes = {
     /**
      * Programming language name
      */
@@ -58,6 +54,14 @@ Code.propTypes = {
      * Additional classes for code
      */
     additionalClasses: PropTypes.arrayOf(PropTypes.string),
+};
+
+Code.propTypes = {
+    ...codePropTypes,
+    /**
+     * Code content
+     */
+    children: PropTypes.string.isRequired,
 };
 
 export default Code;

--- a/src/components/Content/Content.js
+++ b/src/components/Content/Content.js
@@ -1,15 +1,15 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import Code from '../Code/Code';
-import Delimiter from '../Delimiter/Delimiter';
-import File from '../File/File';
-import Header from '../Header/Header';
-import List from '../List/List';
-import Paragraph from '../Paragraph/Paragraph';
-import Quote from '../Quote/Quote';
-import Table from '../Table/Table';
-import Warning from '../Warning/Warning';
-import YouTubeEmbed from '../YouTubeEmbed/YouTubeEmbed';
+import Code, { codePropTypes } from '../Code/Code';
+import Delimiter, { delimiterPropTypes } from '../Delimiter/Delimiter';
+import File, { filePropTypes } from '../File/File';
+import Header, { headerPropTypes } from '../Header/Header';
+import List, { listPropTypes } from '../List/List';
+import Paragraph, { paragraphPropTypes } from '../Paragraph/Paragraph';
+import Quote, { quotePropTypes } from '../Quote/Quote';
+import Table, { tablePropTypes } from '../Table/Table';
+import Warning, { warningPropTypes } from '../Warning/Warning';
+import YouTubeEmbed, { youTubeEmbedPropTypes } from '../YouTubeEmbed/YouTubeEmbed';
 
 export const defaults = {
     headerProps: {},
@@ -92,7 +92,7 @@ const Content = ({
                     caption={block.data.caption}
                     fileName={block.data.fileName}
                     extension={block.data.extension}
-                    stretched={block.data.stretched}
+                    stretched={!!block.data.stretched}
                     {...fileProps}
                     key={block.id}
                 />
@@ -167,43 +167,43 @@ Content.propTypes = {
     /**
      * Additional props for header component, for more information check Header component
      */
-    headerProps: Header.propTypes,
+    headerProps: PropTypes.shape(headerPropTypes),
     /**
      * Additional props for paragraph component, for more information check Paragraph component
      */
-    paragraphProps: Paragraph.propTypes,
+    paragraphProps: PropTypes.shape(paragraphPropTypes),
     /**
      * Additional props for YouTube embed component, for more information check YouTubeEmbed component
      */
-    youTubeEmbedProps: YouTubeEmbed.propTypes,
+    youTubeEmbedProps: PropTypes.shape(youTubeEmbedPropTypes),
     /**
      * Additional props for file components, for more information check File component
      */
-    fileProps: File.propTypes,
+    fileProps: PropTypes.shape(filePropTypes),
     /**
      * Additional props for quote component, for more information check Quote components
      */
-    quoteProps: Quote.propTypes,
+    quoteProps: PropTypes.shape(quotePropTypes),
     /**
      * Additional props for table component, for more information check Table component
      */
-    tableProps: Table.propTypes,
+    tableProps: PropTypes.shape(tablePropTypes),
     /**
      * Additional props for code component, for more information check Code component
      */
-    codeProps: Code.propTypes,
+    codeProps: PropTypes.shape(codePropTypes),
     /**
      * Additional props for warning component, for more information check Warning component
      */
-    warningProps: Warning.propTypes,
+    warningProps: PropTypes.shape(warningPropTypes),
     /**
      * Additional props for delimiter component, for more information check Delimiter component
      */
-    delimiterProps: Delimiter.propTypes,
+    delimiterProps: PropTypes.shape(delimiterPropTypes),
     /**
      * Additional components for list component, for more information check List component
      */
-    listProps: List.propTypes,
+    listProps: PropTypes.shape(listPropTypes),
     /**
      * Standard horizontal padding for block components
      */

--- a/src/components/Delimiter/Delimiter.js
+++ b/src/components/Delimiter/Delimiter.js
@@ -31,7 +31,7 @@ const Delimiter = ({
     );
 };
 
-Delimiter.propTypes = {
+export const delimiterPropTypes = {
     /**
      * Delimiter variant
      */
@@ -54,5 +54,7 @@ Delimiter.propTypes = {
      */
     additionalClasses: PropTypes.arrayOf(PropTypes.string),
 };
+
+Delimiter.propTypes = delimiterPropTypes;
 
 export default Delimiter;

--- a/src/components/File/File.js
+++ b/src/components/File/File.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Image from '../Image/Image';
-import Video from '../Video/Video';
-import Audio from '../Audio/Audio';
+import Image, { imagePropTypes } from '../Image/Image';
+import Video, { videoPropTypes } from '../Video/Video';
+import Audio, { audioPropTypes } from '../Audio/Audio';
 
 export const defaults = {
     caption: null,
@@ -66,11 +66,7 @@ const isImage = (extension) => ['jpg', 'png', 'bmp', 'svg', 'gif', 'webp', 'ico'
 
 const isAudio = (extension) => ['mpeg', 'mp3', 'mid', 'ogg', 'oga', 'wav'].indexOf(extension) > -1;
 
-File.propTypes = {
-    /**
-     * File url
-     */
-    url: PropTypes.string.isRequired,
+export const filePropTypes = {
     /**
      * File caption
      */
@@ -82,7 +78,7 @@ File.propTypes = {
     /**
      * File extension
      */
-    extension: PropTypes.string.isRequired,
+    extension: PropTypes.string,
     /**
      * File name
      */
@@ -90,19 +86,31 @@ File.propTypes = {
     /**
      * Additional props for image components, for more information check Image component
      */
-    imageProps: Image.propTypes,
+    imageProps: PropTypes.shape(imagePropTypes),
     /**
      * Additional props for video components, for more information check Video component
      */
-    videoProps: Video.propTypes,
+    videoProps: PropTypes.shape(videoPropTypes),
     /**
      * Additional props for audio components, for more information check Audio component
      */
-    audioProps: Audio.propTypes,
+    audioProps: PropTypes.shape(audioPropTypes),
     /**
      * Additional classes for file
      */
     additionalClasses: PropTypes.arrayOf(PropTypes.string),
+};
+
+File.propTypes = {
+    /**
+     * File url
+     */
+    url: PropTypes.string.isRequired,
+    /**
+     * File extension
+     */
+    extension: PropTypes.string.isRequired,
+    ...filePropTypes,
 };
 
 export default File;

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -67,15 +67,11 @@ const Header = ({
     );
 };
 
-Header.propTypes = {
+export const headerPropTypes = {
     /**
      * Level of header
      */
     level: PropTypes.number,
-    /**
-     * Header contents
-     */
-    children: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
     /**
      * Header anchor
      */
@@ -112,6 +108,14 @@ Header.propTypes = {
      * Additional classes for level 6 header
      */
     h6AdditionalClasses: PropTypes.arrayOf(PropTypes.string),
+};
+
+Header.propTypes = {
+    /**
+     * Header contents
+     */
+    children: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+    ...headerPropTypes,
 };
 
 export default Header;

--- a/src/components/Image/Image.js
+++ b/src/components/Image/Image.js
@@ -40,11 +40,11 @@ const Image = ({
     </>
 );
 
-Image.propTypes = {
+export const imagePropTypes = {
     /**
      * Image url
      */
-    url: PropTypes.string.isRequired,
+    url: PropTypes.string,
     /**
      * Image caption
      */
@@ -65,6 +65,14 @@ Image.propTypes = {
      * Additional classes for image caption
      */
     captionAdditionalClasses: PropTypes.arrayOf(PropTypes.string),
+};
+
+Image.propTypes = {
+    ...imagePropTypes,
+    /**
+     * Image url
+     */
+    url: PropTypes.string.isRequired,
 };
 
 export default Image;

--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -55,11 +55,11 @@ const Items = {
 };
 Items.items = PropTypes.arrayOf(PropTypes.shape(Items));
 
-List.propTypes = {
+export const listPropTypes = {
     /**
      * List content
      */
-    items: PropTypes.arrayOf(PropTypes.shape(Items)).isRequired,
+    items: PropTypes.arrayOf(PropTypes.shape(Items)),
     /**
      * List style
      */
@@ -72,6 +72,14 @@ List.propTypes = {
      * Additional classes for list
      */
     additionalClasses: PropTypes.arrayOf(PropTypes.string),
+};
+
+List.propTypes = {
+    ...listPropTypes,
+    /**
+     * List content
+     */
+    items: PropTypes.arrayOf(PropTypes.shape(Items)).isRequired,
 };
 
 export default List;

--- a/src/components/Paragraph/Paragraph.js
+++ b/src/components/Paragraph/Paragraph.js
@@ -12,7 +12,8 @@ export const defaults = {
 const Paragraph = ({
     alignment = defaults.alignment,
     additionalClasses = defaults.additionalClasses,
-    children, ...props
+    children,
+    ...props
 }) => {
     const alignmentClass = {
         left: 'text-left',
@@ -36,11 +37,7 @@ const Paragraph = ({
     );
 };
 
-Paragraph.propTypes = {
-    /**
-     * Paragraph content
-     */
-    children: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+export const paragraphPropTypes = {
     /**
      * Paragraph alignment
      */
@@ -49,6 +46,14 @@ Paragraph.propTypes = {
      * Additional classes for paragraph
      */
     additionalClasses: PropTypes.arrayOf(PropTypes.string),
+};
+
+Paragraph.propTypes = {
+    /**
+     * Paragraph content
+     */
+    children: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+    ...paragraphPropTypes,
 };
 
 export default Paragraph;

--- a/src/components/Quote/Quote.js
+++ b/src/components/Quote/Quote.js
@@ -52,15 +52,15 @@ const Quote = ({
     </div>
 );
 
-Quote.propTypes = {
+export const quotePropTypes = {
     /**
      * Quote content
      */
-    text: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+    text: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     /**
      * Quote caption
      */
-    caption: PropTypes.string.isRequired,
+    caption: PropTypes.string,
     /**
      * Quote variant
      */
@@ -87,6 +87,18 @@ Quote.propTypes = {
      * Additional classes for quote caption
      */
     captionAdditionalClasses: PropTypes.arrayOf(PropTypes.string),
+};
+
+Quote.propTypes = {
+    ...quotePropTypes,
+    /**
+     * Quote content
+     */
+    text: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+    /**
+     * Quote caption
+     */
+    caption: PropTypes.string.isRequired,
 };
 
 export default Quote;

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -41,7 +41,7 @@ const Table = ({
     </table>
 );
 
-Table.propTypes = {
+export const tablePropTypes = {
     /**
      * Table contents
      */
@@ -57,5 +57,7 @@ Table.propTypes = {
      */
     additionalClasses: PropTypes.arrayOf(PropTypes.string),
 };
+
+Table.propTypes = tablePropTypes;
 
 export default Table;

--- a/src/components/Video/Video.js
+++ b/src/components/Video/Video.js
@@ -26,15 +26,15 @@ const Video = ({
     </div>
 );
 
-Video.propTypes = {
+export const videoPropTypes = {
     /**
      * Video url
      */
-    url: PropTypes.string.isRequired,
+    url: PropTypes.string,
     /**
      * File extension
      */
-    extension: PropTypes.string.isRequired,
+    extension: PropTypes.string,
     /**
      * Video caption
      */
@@ -43,6 +43,18 @@ Video.propTypes = {
      * Additional classes for video
      */
     additionalClasses: PropTypes.arrayOf(PropTypes.string),
+};
+
+Video.propTypes = {
+    ...videoPropTypes,
+    /**
+     * Video url
+     */
+    url: PropTypes.string.isRequired,
+    /**
+     * File extension
+     */
+    extension: PropTypes.string.isRequired,
 };
 
 export default Video;

--- a/src/components/Warning/Warning.js
+++ b/src/components/Warning/Warning.js
@@ -16,7 +16,23 @@ const Warning = ({ message, title, additionalClasses = defaults.additionalClasse
     </div>
 );
 
+export const warningPropTypes = {
+    /**
+     * Warning message
+     */
+    message: PropTypes.string,
+    /**
+     * Warning title
+     */
+    title: PropTypes.string,
+    /**
+     * Additional classes for warning
+     */
+    additionalClasses: PropTypes.arrayOf(PropTypes.string),
+};
+
 Warning.propTypes = {
+    ...warningPropTypes,
     /**
      * Warning message
      */
@@ -25,10 +41,6 @@ Warning.propTypes = {
      * Warning title
      */
     title: PropTypes.string.isRequired,
-    /**
-     * Additional classes for warning
-     */
-    additionalClasses: PropTypes.arrayOf(PropTypes.string),
 };
 
 export default Warning;

--- a/src/components/YouTubeEmbed/YouTubeEmbed.js
+++ b/src/components/YouTubeEmbed/YouTubeEmbed.js
@@ -37,11 +37,11 @@ const YouTubeEmbed = ({
     );
 };
 
-YouTubeEmbed.propTypes = {
+export const youTubeEmbedPropTypes = {
     /**
-     * YouTUbe url
+     * YouTube url
      */
-    url: PropTypes.string.isRequired,
+    url: PropTypes.string,
     /**
      * Title of iframe
      */
@@ -54,6 +54,14 @@ YouTubeEmbed.propTypes = {
      * Additional classes for embed
      */
     additionalClasses: PropTypes.arrayOf(PropTypes.string),
+};
+
+YouTubeEmbed.propTypes = {
+    ...youTubeEmbedPropTypes,
+    /**
+     * YouTube url
+     */
+    url: PropTypes.string.isRequired,
 };
 
 export default YouTubeEmbed;


### PR DESCRIPTION
This fix warnings:

- Warning: Failed prop type: Content: prop type `headerProps` is invalid; it must be a function, usually from the `prop-types` package, but received `object`.This often happens because of typos such as `PropTypes.function` instead of `PropTypes.func`.
- Warning: Failed prop type: Content: prop type `paragraphProps` is invalid; it must be a function, usually from the `prop-types` package, but received `object`.This often happens because of typos such as `PropTypes.function` instead of `PropTypes.func`.
- Warning: Failed prop type: Content: prop type `youTubeEmbedProps` is invalid; it must be a function, usually from the `prop-types` package, but received `object`.This often happens because of typos such as `PropTypes.function` instead of `PropTypes.func`.
- etc.

Caused by compilation of propTypes as function instead of object